### PR TITLE
Fix page duplication on reload

### DIFF
--- a/lib/pdfjs-viewer-view.js
+++ b/lib/pdfjs-viewer-view.js
@@ -252,6 +252,7 @@ export default class PdfjsViewerView {
       // Appears to have been solved by changing the file watcher,
       // left here for future reference in case not.
       //  win.PDFViewerApplication.eventBus.on('documentinit', (e) => console.log(e))
+      win.PDFViewerApplication.close()
       win.PDFViewerApplication.open(this.pdfPathname)
     } else {
       console.log('PdfjsViewerView: cannot (yet) reload PDF')


### PR DESCRIPTION
Fixes page duplication and excessive thread creation as discussed in https://github.com/allefeld/atom-pdfjs-viewer/issues/11#issue-866992776
